### PR TITLE
Agrega meta data para Twitter Cards

### DIFF
--- a/_includes/_twitter_summary.html
+++ b/_includes/_twitter_summary.html
@@ -1,0 +1,22 @@
+<meta name="twitter:card" content="summary">
+<meta name="twitter:site" content="@codeandomexico">
+<meta name="twitter:creator" content="@codeandomexico">
+<meta name="twitter:domain" content="Codeando México">
+{% if page.title %}
+<meta name="twitter:title" content="{{ page.title }}">
+{% else %}
+<meta name="twitter:title" content="{{ site.title }}">
+{% endif %}
+{% if page.url %}
+<meta name="twitter:url" content="{{ site.url }}{{ page.url }}">
+{% endif %}
+{% if page.description %}
+<meta name="twitter:description" content="{{ page.description }}">
+{% else %}
+<meta name="twitter:description" content="{{ site.description }}">
+{% endif %}
+{% if page.image %}
+<meta name="twitter:image:src" content="{{ site.url }}/path/to/image/{{ page.image }}">
+{% else %}
+<meta name="twitter:image:src" content="{{ site.url }}/path/to/image/logo.png">
+{% endif %}

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -27,6 +27,7 @@
     <meta name="description" content="{{ page.excerpt }}"/>
     {% endif %}
     <meta property="og:site_name" content="{{ site.inc.title }}">     
+    {% include _twitter_summary.html %}
 </head>
 <body>
     


### PR DESCRIPTION
![Summary Card](https://dev.twitter.com/sites/default/files/images_documentation/web_summary_1.png)

Quería poner el include dentro de `_post.html` pero no jalaba por alguna razón.

Aquí vienen los fields que pueden ponerle al metadata. [Twitter Card Validator](https://dev.twitter.com/docs/cards/validation/validator)

la parte de twitter:site, twitter:creator y twitter:domain, no estoy seguro que quieran poner ahi. Para site y creator creo que son @handles.
